### PR TITLE
出品者の購入画面遷移制限

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,7 @@
 class OrdersController < ApplicationController
   before_action :authenticate_user!, expect: [:index, :new]
   before_action :set_item, only: [:index, :order_params]
+  before_action :check_user, only: [:index]
 
   def index
     set_bought
@@ -56,4 +57,12 @@ class OrdersController < ApplicationController
       end
     end
   end
+
+  def check_user
+    if current_user.id == @item.user.id 
+      redirect_to root_path
+      return
+    end
+  end  
+
 end


### PR DESCRIPTION
what
出品者の購入画面遷移制限
why
出品者が誤って購入することを防ぐため